### PR TITLE
Add voice param to audio message

### DIFF
--- a/lib/whatsapp_sdk/api/messages.rb
+++ b/lib/whatsapp_sdk/api/messages.rb
@@ -113,7 +113,7 @@ module WhatsappSdk
       # @param link [String] Audio link.
       # @param message_id [String] The id of the message to reply to.
       # @return [MessageDataResponse] Response object.
-      def send_audio(sender_id:, recipient_number:, audio_id: nil, link: nil, message_id: nil)
+      def send_audio(sender_id:, recipient_number:, audio_id: nil, link: nil, message_id: nil, voice: false)
         raise Resource::Errors::MissingArgumentError, "audio_id or link is required" if !audio_id && !link
 
         params = {
@@ -122,7 +122,7 @@ module WhatsappSdk
           recipient_type: "individual",
           type: "audio"
         }
-        params[:audio] = link ? { link: link } : { id: audio_id }
+        params[:audio] = link ? { link: link, voice: voice } : { id: audio_id, voice: voice }
         params[:context] = { message_id: message_id } if message_id
 
         response = send_request(

--- a/test/whatsapp/api/messages_test.rb
+++ b/test/whatsapp/api/messages_test.rb
@@ -177,7 +177,7 @@ module WhatsappSdk
       def test_send_audio_message_with_success_response
         VCR.use_cassette("messages/send_audio_message_with_success_response") do
           message_response = @messages_api.send_audio(
-            sender_id: @sender_id, recipient_number: @recipient_number, audio_id: "914268667232441"
+            sender_id: @sender_id, recipient_number: @recipient_number, audio_id: "914268667232441", voice: false
           )
 
           assert_message_response({
@@ -190,7 +190,7 @@ module WhatsappSdk
       def test_send_audio_raises_an_error_if_link_and_id_are_not_provided
         assert_raises(Resource::Errors::MissingArgumentError) do
           @messages_api.send_audio(
-            sender_id: 123_123, recipient_number: 56_789, link: nil, audio_id: nil
+            sender_id: 123_123, recipient_number: 56_789, link: nil, audio_id: nil, voice: false
           )
         end
       end
@@ -200,7 +200,7 @@ module WhatsappSdk
           link = "https://lookaside.fbsbx.com/whatsapp_business/attachments/?mid=914268667232441&" \
                  "ext=1728913145&hash=ATtV69tQN8OKiNmN_0SYR73eo3kshm76rQwUvIpfbVAHrA"
           message_response = @messages_api.send_audio(
-            sender_id: @sender_id, recipient_number: @recipient_number, link: link
+            sender_id: @sender_id, recipient_number: @recipient_number, link: link, voice: false
           )
 
           assert_message_response({
@@ -213,7 +213,7 @@ module WhatsappSdk
       def test_send_audio_message_with_an_audio_id
         VCR.use_cassette("messages/send_audio_message_with_success_response") do
           message_response = @messages_api.send_audio(
-            sender_id: @sender_id, recipient_number: @recipient_number, audio_id: "914268667232441"
+            sender_id: @sender_id, recipient_number: @recipient_number, audio_id: "914268667232441", voice: false
           )
 
           assert_message_response({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added voice message support to audio sending with a configurable flag parameter (default: disabled), enabling the ability to distinguish between regular audio and voice messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->