### PR TITLE
Add recipient (BSUID) support to Messages send_* methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# v 1.0.3.1 (oitedi fork)
+- Add `recipient` (Business-Scoped User ID / BSUID) support to all `Messages#send_*` methods. `recipient_number` is now optional; at least one destination (`recipient_number` or `recipient`) is required. Phone takes precedence when both are given.
+- Validate that `recipient` (BSUID) is not used with authentication templates (`one_tap`, `zero_tap`, `copy_code`).
+
 # v 1.0.3
 -  Fix configuration bug setting `api_version` on Configure. @frenesim [#168](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/168)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    whatsapp_sdk (1.0.3)
+    whatsapp_sdk (1.0.3.1)
       faraday (~> 2.0, > 2.0.1)
       faraday-multipart (~> 1)
       zeitwerk (~> 2)

--- a/README.md
+++ b/README.md
@@ -237,6 +237,13 @@ client.media.delete(media_id: MEDIA_ID)
 # Send a text message
 client.messages.send_text(sender_id: 1234, recipient_number: 112345678, message: "hola")
 
+# Send a message by Business-Scoped User ID (BSUID) when the phone number is not available
+#   (e.g. the user adopted a WhatsApp username and hid their phone number).
+#   `recipient_number` becomes optional; pass `recipient` with the BSUID instead.
+#   At least one of `recipient_number` / `recipient` is required. When both are given, the phone takes precedence.
+#   Not supported by authentication templates (one_tap, zero_tap, copy_code).
+client.messages.send_text(sender_id: 1234, recipient: "BR.1786593138972580", message: "hola")
+
 # Read a message
 client.messages.read_message(sender_id: 1234, message_id: "wamid.HBgLMTM0M12345678910=")
 

--- a/lib/whatsapp_sdk/api/messages.rb
+++ b/lib/whatsapp_sdk/api/messages.rb
@@ -7,14 +7,18 @@ module WhatsappSdk
     class Messages < Request
       DEFAULT_HEADERS = { 'Content-Type' => 'application/json' }.freeze
 
+      # Authentication-template button sub-types. BSUID (`recipient`) is not allowed for these.
+      AUTH_TEMPLATE_MARKERS = %w[one_tap zero_tap copy_code].freeze
+
       # Send a text message.
       #
       # @param sender_id [Integer] Sender' phone number.
       # @param recipient_number [Integer] Recipient' Phone number.
       # @param message [String] Text to send.
       # @param message_id [String] The id of the message to reply to.
+      # @param recipient [String] Recipient' Business-Scoped User ID (BSUID). Optional alternative to recipient_number.
       # @return [MessageDataResponse] Response object.
-      def send_text(sender_id:, recipient_number:, message:, message_id: nil)
+      def send_text(sender_id:, message:, recipient_number: nil, message_id: nil, recipient: nil)
         params = {
           messaging_product: "whatsapp",
           to: recipient_number,
@@ -23,6 +27,7 @@ module WhatsappSdk
           text: { body: message }
         }
         params[:context] = { message_id: message_id } if message_id
+        apply_recipient!(params, recipient_number, recipient)
 
         response = send_request(
           endpoint: endpoint(sender_id),
@@ -42,9 +47,10 @@ module WhatsappSdk
       # @param name [String] Location name.
       # @param address [String] Location address.
       # @param message_id [String] The id of the message to reply to.
+      # @param recipient [String] Recipient' Business-Scoped User ID (BSUID). Optional alternative to recipient_number.
       # @return [MessageDataResponse] Response object.
       def send_location(
-        sender_id:, recipient_number:, longitude:, latitude:, name:, address:, message_id: nil
+        sender_id:, longitude:, latitude:, name:, address:, recipient_number: nil, message_id: nil, recipient: nil
       )
         params = {
           messaging_product: "whatsapp",
@@ -59,6 +65,7 @@ module WhatsappSdk
           }
         }
         params[:context] = { message_id: message_id } if message_id
+        apply_recipient!(params, recipient_number, recipient)
 
         response = send_request(
           endpoint: endpoint(sender_id),
@@ -77,9 +84,10 @@ module WhatsappSdk
       # @param link [String] Image link.
       # @param caption [String] Image caption.
       # @param message_id [String] The id of the message to reply to.
+      # @param recipient [String] Recipient' Business-Scoped User ID (BSUID). Optional alternative to recipient_number.
       # @return [MessageDataResponse] Response object.
       def send_image(
-        sender_id:, recipient_number:, image_id: nil, link: nil, caption: "", message_id: nil
+        sender_id:, recipient_number: nil, image_id: nil, link: nil, caption: "", message_id: nil, recipient: nil
       )
         raise Resource::Errors::MissingArgumentError, "image_id or link is required" if !image_id && !link
 
@@ -95,6 +103,7 @@ module WhatsappSdk
                            { id: image_id, caption: caption }
                          end
         params[:context] = { message_id: message_id } if message_id
+        apply_recipient!(params, recipient_number, recipient)
 
         response = send_request(
           endpoint: endpoint(sender_id),
@@ -112,8 +121,10 @@ module WhatsappSdk
       # @param audio_id [String] Audio ID.
       # @param link [String] Audio link.
       # @param message_id [String] The id of the message to reply to.
+      # @param voice [Boolean] Whether the audio is a voice note.
+      # @param recipient [String] Recipient' Business-Scoped User ID (BSUID). Optional alternative to recipient_number.
       # @return [MessageDataResponse] Response object.
-      def send_audio(sender_id:, recipient_number:, audio_id: nil, link: nil, message_id: nil, voice: false)
+      def send_audio(sender_id:, recipient_number: nil, audio_id: nil, link: nil, message_id: nil, voice: false, recipient: nil)
         raise Resource::Errors::MissingArgumentError, "audio_id or link is required" if !audio_id && !link
 
         params = {
@@ -124,6 +135,7 @@ module WhatsappSdk
         }
         params[:audio] = link ? { link: link, voice: voice } : { id: audio_id, voice: voice }
         params[:context] = { message_id: message_id } if message_id
+        apply_recipient!(params, recipient_number, recipient)
 
         response = send_request(
           endpoint: endpoint(sender_id),
@@ -143,9 +155,10 @@ module WhatsappSdk
       # @param link [String] Image link.
       # @param caption [String] Image caption.
       # @param message_id [String] The id of the message to reply to.
+      # @param recipient [String] Recipient' Business-Scoped User ID (BSUID). Optional alternative to recipient_number.
       # @return [MessageDataResponse] Response object.
       def send_video(
-        sender_id:, recipient_number:, video_id: nil, link: nil, caption: "", message_id: nil
+        sender_id:, recipient_number: nil, video_id: nil, link: nil, caption: "", message_id: nil, recipient: nil
       )
         raise Resource::Errors::MissingArgumentError, "video_id or link is required" if !video_id && !link
 
@@ -161,6 +174,7 @@ module WhatsappSdk
                            { id: video_id, caption: caption }
                          end
         params[:context] = { message_id: message_id } if message_id
+        apply_recipient!(params, recipient_number, recipient)
 
         response = send_request(
           endpoint: endpoint(sender_id),
@@ -179,9 +193,11 @@ module WhatsappSdk
       # @param link [String] Image link.
       # @param caption [String] Image caption.
       # @param message_id [String] The id of the message to reply to.
+      # @param recipient [String] Recipient' Business-Scoped User ID (BSUID). Optional alternative to recipient_number.
       # @return [MessageDataResponse] Response object.
       def send_document(
-        sender_id:, recipient_number:, document_id: nil, link: nil, caption: "", message_id: nil, filename: nil
+        sender_id:, recipient_number: nil, document_id: nil, link: nil, caption: "", message_id: nil,
+        filename: nil, recipient: nil
       )
         if !document_id && !link
           raise Resource::Errors::MissingArgumentError,
@@ -201,6 +217,7 @@ module WhatsappSdk
                             end
         params[:document] = params[:document].merge({ filename: filename }) if filename
         params[:context] = { message_id: message_id } if message_id
+        apply_recipient!(params, recipient_number, recipient)
 
         response = send_request(
           endpoint: endpoint(sender_id),
@@ -211,15 +228,16 @@ module WhatsappSdk
         Api::Responses::MessageDataResponse.build_from_response(response: response)
       end
 
-      # Send a document.
+      # Send a sticker.
       #
       # @param sender_id [Integer] Sender' phone number.
       # @param recipient_number [Integer] Recipient' Phone number.
       # @param sticker_id [String] The sticker ID.
       # @param link [String] Image link.
       # @param message_id [String] The id of the message to reply to.
+      # @param recipient [String] Recipient' Business-Scoped User ID (BSUID). Optional alternative to recipient_number.
       # @return [MessageDataResponse] Response object.
-      def send_sticker(sender_id:, recipient_number:, sticker_id: nil, link: nil, message_id: nil)
+      def send_sticker(sender_id:, recipient_number: nil, sticker_id: nil, link: nil, message_id: nil, recipient: nil)
         raise Resource::Errors::MissingArgumentError, "sticker or link is required" if !sticker_id && !link
 
         params = {
@@ -230,6 +248,7 @@ module WhatsappSdk
         }
         params[:sticker] = link ? { link: link } : { id: sticker_id }
         params[:context] = { message_id: message_id } if message_id
+        apply_recipient!(params, recipient_number, recipient)
 
         response = send_request(
           endpoint: endpoint(sender_id),
@@ -248,9 +267,10 @@ module WhatsappSdk
       # @param contacts [Array<Contact>] Contacts.
       # @param contacts_json [Json] Contacts.
       # @param message_id [String] The id of the message to reply to.
+      # @param recipient [String] Recipient' Business-Scoped User ID (BSUID). Optional alternative to recipient_number.
       # @return [MessageDataResponse] Response object.
       def send_contacts(
-        sender_id:, recipient_number:, contacts: nil, contacts_json: {}, message_id: nil
+        sender_id:, recipient_number: nil, contacts: nil, contacts_json: {}, message_id: nil, recipient: nil
       )
         params = {
           messaging_product: "whatsapp",
@@ -260,6 +280,7 @@ module WhatsappSdk
         }
         params[:contacts] = contacts ? contacts.map(&:to_h) : contacts_json
         params[:context] = { message_id: message_id } if message_id
+        apply_recipient!(params, recipient_number, recipient)
 
         response = send_request(
           endpoint: endpoint(sender_id),
@@ -284,9 +305,10 @@ module WhatsappSdk
       # @param interactive_json [Json] The interactive object as a Json.
       #    If you pass interactive_json, you can't pass interactive.
       # @param message_id [String] The id of the message to reply to.
+      # @param recipient [String] Recipient' Business-Scoped User ID (BSUID). Optional alternative to recipient_number.
       # @return [MessageDataResponse] Response object.
       def send_interactive_message(
-        sender_id:, recipient_number:, interactive: nil, interactive_json: nil, message_id: nil
+        sender_id:, recipient_number: nil, interactive: nil, interactive_json: nil, message_id: nil, recipient: nil
       )
         if !interactive && !interactive_json
           raise Resource::Errors::MissingArgumentError,
@@ -306,6 +328,7 @@ module WhatsappSdk
                                  interactive.to_json
                                end
         params[:context] = { message_id: message_id } if message_id
+        apply_recipient!(params, recipient_number, recipient)
 
         response = send_request(
           endpoint: endpoint(sender_id),
@@ -348,14 +371,18 @@ module WhatsappSdk
       # @param language [String] template language.
       # @param components [Component] Component.
       # @param components_json [Json] The component as a Json. If you pass components_json, you can't pass components.
+      # @param recipient [String] Recipient' Business-Scoped User ID (BSUID). Optional alternative to recipient_number.
+      #    Not allowed for authentication templates.
       # @return [MessageDataResponse] Response object.
       def send_template(
-        sender_id:, recipient_number:, name:, language:, components: nil, components_json: nil
+        sender_id:, name:, language:, recipient_number: nil, components: nil, components_json: nil, recipient: nil
       )
         if !components && !components_json
           raise Resource::Errors::MissingArgumentError,
                 "components or components_json is required"
         end
+
+        validate_recipient_not_auth_template!(recipient, components, components_json)
 
         params = {
           messaging_product: "whatsapp",
@@ -373,6 +400,7 @@ module WhatsappSdk
                                          else
                                            components.map(&:to_json)
                                          end
+        apply_recipient!(params, recipient_number, recipient)
 
         response = send_request(
           endpoint: endpoint(sender_id),
@@ -389,8 +417,9 @@ module WhatsappSdk
       # @param recipient_number [Integer] Recipient' Phone number.
       # @param message_id [String] the id of the message to reaction.
       # @param emoji [String] unicode of the emoji to send.
+      # @param recipient [String] Recipient' Business-Scoped User ID (BSUID). Optional alternative to recipient_number.
       # @return [MessageDataResponse] Response object.
-      def send_reaction(sender_id:, recipient_number:, message_id:, emoji:)
+      def send_reaction(sender_id:, message_id:, emoji:, recipient_number: nil, recipient: nil)
         params = {
           messaging_product: "whatsapp",
           recipient_type: "individual",
@@ -401,6 +430,7 @@ module WhatsappSdk
             emoji: emoji
           }
         }
+        apply_recipient!(params, recipient_number, recipient)
 
         response = send_request(
           endpoint: endpoint(sender_id),
@@ -440,6 +470,30 @@ module WhatsappSdk
 
       def endpoint(sender_id)
         "#{sender_id}/messages"
+      end
+
+      # Applies the destination to the payload: keeps `to` when a phone number is
+      # given (phone takes precedence) and adds `recipient` (BSUID) when present.
+      # Requires at least one destination.
+      def apply_recipient!(params, recipient_number, recipient)
+        if recipient_number.nil? && recipient.nil?
+          raise Resource::Errors::MissingArgumentError, "recipient_number or recipient is required"
+        end
+
+        params.delete(:to) if recipient_number.nil?
+        params[:recipient] = recipient if recipient
+        params
+      end
+
+      # BSUID (`recipient`) is not supported by authentication templates
+      # (one_tap, zero_tap, copy_code).
+      def validate_recipient_not_auth_template!(recipient, components, components_json)
+        return unless recipient
+
+        serialized = (components_json || components).to_s
+        return unless AUTH_TEMPLATE_MARKERS.any? { |marker| serialized.include?(marker) }
+
+        raise ArgumentError, "recipient (BSUID) is not allowed for authentication templates"
       end
     end
   end

--- a/lib/whatsapp_sdk/version.rb
+++ b/lib/whatsapp_sdk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WhatsappSdk
-  VERSION = "1.0.3"
+  VERSION = "1.0.3.1"
 end

--- a/test/whatsapp/api/messages_test.rb
+++ b/test/whatsapp/api/messages_test.rb
@@ -727,6 +727,77 @@ module WhatsappSdk
         end
       end
 
+      def test_send_text_with_recipient_bsuid_only_sends_recipient_and_omits_to
+        @messages_api.expects(:send_request).with(
+          endpoint: "123123/messages",
+          params: {
+            messaging_product: "whatsapp",
+            recipient_type: "individual",
+            type: "text",
+            text: { body: "hola" },
+            recipient: "BR.1786593138972580"
+          },
+          headers: { "Content-Type" => "application/json" }
+        ).returns(valid_response)
+
+        @messages_api.send_text(
+          sender_id: 123_123, recipient: "BR.1786593138972580", message: "hola"
+        )
+      end
+
+      def test_send_text_with_both_keeps_to_and_adds_recipient
+        @messages_api.expects(:send_request).with(
+          endpoint: "123123/messages",
+          params: {
+            messaging_product: "whatsapp",
+            to: 56_789,
+            recipient_type: "individual",
+            type: "text",
+            text: { body: "hola" },
+            recipient: "BR.123"
+          },
+          headers: { "Content-Type" => "application/json" }
+        ).returns(valid_response)
+
+        @messages_api.send_text(
+          sender_id: 123_123, recipient_number: 56_789, recipient: "BR.123", message: "hola"
+        )
+      end
+
+      def test_send_text_without_destination_raises
+        assert_raises(WhatsappSdk::Resource::Errors::MissingArgumentError) do
+          @messages_api.send_text(sender_id: 123_123, message: "hola")
+        end
+      end
+
+      def test_send_template_with_recipient_bsuid_sends_recipient
+        @messages_api.expects(:send_request).with(
+          endpoint: "123123/messages",
+          params: {
+            messaging_product: "whatsapp",
+            recipient_type: "individual",
+            type: "template",
+            template: { name: "hello", language: { code: "en_US" }, components: { foo: "bar" } },
+            recipient: "BR.123"
+          },
+          headers: { "Content-Type" => "application/json" }
+        ).returns(valid_response)
+
+        @messages_api.send_template(
+          sender_id: 123_123, recipient: "BR.123", name: "hello", language: "en_US",
+          components_json: { foo: "bar" }
+        )
+      end
+
+      def test_send_template_with_recipient_on_auth_template_raises
+        assert_raises(ArgumentError) do
+          @messages_api.send_template(
+            sender_id: 123_123, recipient: "BR.123", name: "otp", language: "en_US",
+            components_json: [{ type: "button", sub_type: "one_tap" }]
+          )
+        end
+      end
+
       private
 
       def valid_response


### PR DESCRIPTION
## Contexto

A partir de mai/2026, a WhatsApp Cloud API aceita endereçar mensagens por **`recipient`** (Business-Scoped User ID / BSUID) além de `to` (telefone) — necessário para enviar a usuários que adotaram username e ocultaram o número. Hoje o SDK só expõe `recipient_number` (telefone).

Parte do épico interno **SCRUM-2724** (adaptação BSUID); este PR cobre a **Story SCRUM-2730**.

## O que muda

- Todos os `Messages#send_*` (`send_text`, `send_template`, `send_image`, `send_video`, `send_audio`, `send_document`, `send_sticker`, `send_contacts`, `send_location`, `send_interactive_message`, `send_reaction`) passam a aceitar **`recipient:`** (BSUID) opcional.
- `recipient_number:` agora é **opcional**; é exigido **ao menos um** destino (`recipient_number` ou `recipient`), senão `MissingArgumentError`.
- Quando ambos são passados, o **telefone tem precedência** (`to` mantido) e `recipient` é incluído.
- Quando só `recipient` é passado, o payload **omite `to`** e envia `recipient`.
- **Validação:** `recipient` (BSUID) não é permitido em templates de autenticação (`one_tap`, `zero_tap`, `copy_code`) → `ArgumentError`.

Tudo é **aditivo/retrocompatível**: chamadas existentes com `recipient_number:` continuam idênticas.

## Implementação

- Helper privado `apply_recipient!(params, recipient_number, recipient)` centraliza a regra de destino (remove `to` quando ausente, adiciona `recipient`, valida presença).
- `validate_recipient_not_auth_template!` no `send_template`.

## Versão

`1.0.3 → 1.0.3.1` (sufixo de patch do fork; **propositalmente não 1.1.0**, que já existe no upstream `ignacio-chiazzo` com outro significado).

## Testes

`bundle exec ruby -Itest -Ilib test/whatsapp/api/messages_test.rb` → **37 runs, 0 failures, 0 errors** (1 skip pré-existente). Novos testes:
- `send_text` só com `recipient` → payload com `recipient`, sem `to`
- `send_text` com ambos → `to` + `recipient`
- `send_text` sem destino → `MissingArgumentError`
- `send_template` com `recipient` → payload com `recipient`
- `send_template` + `recipient` em template auth → `ArgumentError`

## Uso

```ruby
# por telefone (inalterado)
client.messages.send_text(sender_id: 1234, recipient_number: 5585999999999, message: "oi")

# por BSUID (quando o telefone foi ocultado)
client.messages.send_text(sender_id: 1234, recipient: "BR.1786593138972580", message: "oi")
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Business-Scoped User ID (BSUID) support as an alternative recipient identifier across message sending operations.
  * Updated message methods so the phone number can be omitted when BSUID is provided.

* **Bug Fixes**
  * Added validation to require at least one destination (phone number or BSUID).
  * When both are provided, the phone number takes precedence.
  * Prevented BSUID use with authentication-related templates (e.g., one_tap, zero_tap, copy_code).

* **Documentation**
  * Expanded “Send a text message” instructions with BSUID examples and limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->